### PR TITLE
Fix relative path resolution in generated MLCFG files

### DIFF
--- a/run
+++ b/run
@@ -19,10 +19,13 @@ fi
 cargo creusot -- --features=contracts
 
 contracts_location=$(ls -t target/debug/deps/libcreusot_contracts-*.rmeta | head -1)
-output_file="exercises/$(basename $file .rs).mlcfg"
+output_file="$(basename $file .rs).mlcfg"
+base="$(pwd)"
+
+cd "$(dirname $file)"
 
 rustup run $(rustup show active-toolchain | cut -d " "  -f 1) creusot-rustc --output-file=$output_file -- -Zno-codegen \
-  --extern creusot_contracts=$contracts_location \
-  -Ldependency=./target/debug/deps/ \
+  --extern creusot_contracts=$base/$contracts_location \
+  -Ldependency=$base/target/debug/deps/ \
   --crate-type=lib \
-  $file
+  "$(basename $file)"


### PR DESCRIPTION
With the current run script when running the MLCFG files in Why3's IDE, it can't resolve the relative paths to the Rust source. This fixes that problem by running the compiler directly in the source directory. 